### PR TITLE
修复 windows 中读取 user-agents.txt 存在 \r 的问题

### DIFF
--- a/lib/common.py
+++ b/lib/common.py
@@ -71,7 +71,9 @@ def initDirs():
 
 
 def initAgents():
-    agents.extend(readFile(paths.USER_AGENTS).split("\n"))
+    data = readFile(paths.USER_AGENTS).split("\n")
+    data = [t.rstrip('\r').strip() for t in data]
+    agents.extend(data)
 
 
 def readFile(filename):

--- a/lib/common.py
+++ b/lib/common.py
@@ -71,8 +71,8 @@ def initDirs():
 
 
 def initAgents():
-    data = readFile(paths.USER_AGENTS).split("\n")
-    data = [t.rstrip('\r').strip() for t in data]
+    data = readFile(paths.USER_AGENTS).splitlines()
+    data = [t.strip() for t in data if t.strip() != '']
     agents.extend(data)
 
 

--- a/lib/git.py
+++ b/lib/git.py
@@ -99,7 +99,9 @@ def clone_from_cache():
     readorwget("logs/HEAD", True)
     HEAD_HASH = readorwget(refs)
     readorwget("logs/refs/heads/%s" % (refs.split("/")[-1]))
-    cache_commits(HEAD_HASH.replace("\n", ""))
+    
+    if HEAD_HASH:
+        cache_commits(HEAD_HASH.replace("\n", ""))
 
     # 下载 stash
     STASH_HASH = readorwget("refs/stash")
@@ -112,6 +114,7 @@ def clone_from_cache():
 def readorwget(filename, refresh=False):
     filepath = os.path.join(paths.GITHACK_DIST_TARGET_GIT_PATH, filename)
     if refresh or not os.path.exists(filepath):
+        logger.info(filename)
         wget(filename)
     else:
         if DEBUG:


### PR DESCRIPTION
Windows 使用 \r\n 换行，未对读取的 user-agents.txt 内容做过滤，没有去掉每行最后的 \r，在 /lib/request/request_data 函数中，会因为设置的 UserAgent 存在 \r 而出现异常。

initAgents

```py
def initAgents():
    data = readFile(paths.USER_AGENTS).split("\n")
    data = [t.rstrip('\r').strip() for t in data]
    agents.extend(data)
```

request_data

```py
def request_data(url):
    for i in range(3):
        data = None
        try:
            request = urllib2.Request(url, None, {'User-Agent': randomAgent()})
            data = urllib2.urlopen(request).read()
            if data:
                return data
        except Exception, e:
            if DEBUG:
                logger.warning("Request Exception: %s" % str(e))
    return None
```