### PR TITLE
更新日志

### DIFF
--- a/lib/common.py
+++ b/lib/common.py
@@ -8,7 +8,7 @@ See the file 'LICENCE' for copying permission
 
 import sys
 import os
-import urlparse
+from urllib import parse
 from lib.data import logger
 from lib.data import paths
 from lib.data import target
@@ -47,7 +47,7 @@ def banner():
 def setPaths(url):
     logger.info("Set Paths")
     target.TARGET_GIT_URL = url if (url[-1] == "/") else url + "/"
-    target.TARGET_DIST = urlparse.urlparse(target.TARGET_GIT_URL).netloc.replace(':', '_')
+    target.TARGET_DIST = parse.urlparse(target.TARGET_GIT_URL).netloc.replace(':', '_')
     logger.info("Target Url: %s" % (target.TARGET_GIT_URL))
     paths.GITHACK_DIST_ROOT_PATH = os.path.join(paths.GITHACK_ROOT_PATH, "dist")
     paths.GITHACK_DATA_PATH = os.path.join(paths.GITHACK_ROOT_PATH, "data")
@@ -81,7 +81,7 @@ def readFile(filename):
     try:
         with open(filename, "rb") as f:
             retVal = f.read()
-    except IOError, ex:
+    except IOError as ex:
         errMsg = "something went wrong while trying to read "
         errMsg += "the input file ('%s')" % ex
         # raise IOError(errMsg)
@@ -92,7 +92,7 @@ def writeFile(filename, data):
     try:
         with open(filename, "wb") as f:
             f.write(data)
-    except IOError, ex:
+    except IOError as ex:
         errMsg = "something went wrong while trying to write "
         errMsg += "to the output file ('%s')" % ex
         # raise IOError(errMsg)

--- a/lib/request.py
+++ b/lib/request.py
@@ -7,7 +7,7 @@ See the file 'LICENCE' for copying permission
 """
 
 import os
-import urllib2
+import urllib.request
 import random
 from lib.common import writeFile
 from lib.data import paths
@@ -29,7 +29,7 @@ def request_data(url):
             data = urllib2.urlopen(request).read()
             if data:
                 return data
-        except Exception, e:
+        except Exception as e:
             if DEBUG:
                 logger.warning("Request Exception: %s" % str(e))
     return None

--- a/python版本问题说明.md
+++ b/python版本问题说明.md
@@ -1,0 +1,17 @@
+项目中的py代码在python3版本下运行会报错，一般会报错：
+
+\#common.py
+
+import urlparse
+
+No module named 'urlparse'
+
+\#request.py
+
+import urllib2
+
+No module named 'urllib2'
+
+这是版本问题，因为python3版本中已经将urllib2、urlparse并入了urllib模块中，并且修改urllib模块，其中包含5个子模块：urllib.error,urllib.parse,urllib.request,urllib.response,urllib.robotparser。还有python2和python3版本的try-catch也有点不同。 这个问题只涉及到了lib中的common.py和request.py，所以只需要对这两个文件做出相应修改。
+
+（PS：如果还有其他错，应该是包的问题了，pip install +相应的包就没问题了。）


### PR DESCRIPTION
项目中的部分py代码因为python版本问题，在python3版本下运行会报错，一般会报错：

\#common.py

import urlparse

No module named 'urlparse'

\#request.py

import urllib2

No module named 'urllib2'

因为python3版本中已经将urllib2、urlparse并入了urllib模块中，并且修改urllib模块，其中包含5个子模块：urllib.error,urllib.parse,urllib.request,urllib.response,urllib.robotparser。还有python2和python3版本的try-catch也有点不同。 只有lib文件夹中的common.py和request.py有这个问题，所以我对common.py和request.py这两个文件做出了相应修改。（第一次提交pr，有做的不对的地方请见谅）