### PR TITLE
修复 .git/logs/ 目录默认不会创建导致 logs 记录丢失的问题

### DIFF
--- a/lib/git.py
+++ b/lib/git.py
@@ -91,9 +91,12 @@ def clone_from_cache():
     logger.info("Cache files")
     refresh_files()
     readorwget("COMMIT_EDITMSG")
+    readorwget("ORIG_HEAD")
+    readorwget("description")
     readorwget("info/exclude")
     readorwget("FETCH_HEAD")
-    readorwget("/refs/heads/master")
+    readorwget("refs/heads/master")
+    readorwget("refs/remote/master")
     refs = readorwget("HEAD")[5:-1]
     readorwget("index")
     readorwget("logs/HEAD", True)
@@ -103,6 +106,8 @@ def clone_from_cache():
     if HEAD_HASH:
         cache_commits(HEAD_HASH.replace("\n", ""))
 
+    readorwget("logs/refs/remote/master")
+    readorwget("logs/refs/stash")
     # 下载 stash
     STASH_HASH = readorwget("refs/stash")
     if STASH_HASH:

--- a/lib/request.py
+++ b/lib/request.py
@@ -38,6 +38,9 @@ def request_data(url):
 def wget(filepath):
     url = "%s%s" % (target.TARGET_GIT_URL, filepath)
     filename = os.path.join(paths.GITHACK_DIST_TARGET_GIT_PATH, filepath)
+    dirname = os.path.dirname(filename)
+    if not os.path.exists(dirname):
+        os.makedirs(dirname)
     data = request_data(url)
     if data:
         writeFile(filename, data)


### PR DESCRIPTION
* 修复了部分目录不会默认创建，导致 clone 不完整的问题
* 新增了几个文件主要是 `logs/refs/stash`，这样在目标有 stash 的情况下，clone 之后就可以执行 `git stash list` 查看所有的 stash 了
